### PR TITLE
Go 1.18: rewrite `interface{}` to `any`

### DIFF
--- a/app/wtf_app.go
+++ b/app/wtf_app.go
@@ -212,7 +212,7 @@ func (wtfApp *WtfApp) watchForConfigChanges() {
 
 				config := cfg.LoadWtfConfigFile(wtfApp.configFilePath)
 				newApp := NewWtfApp(wtfApp.TViewApp, config, wtfApp.configFilePath)
-				openURLUtil := utils.ToStrs(config.UList("wtf.openUrlUtil", []interface{}{}))
+				openURLUtil := utils.ToStrs(config.UList("wtf.openUrlUtil", []any{}))
 				utils.Init(config.UString("wtf.openFileUtil", "open"), openURLUtil)
 
 				newApp.Start()

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 	}
 
 	openFileUtil := config.UString("wtf.openFileUtil", "open")
-	openURLUtil := utils.ToStrs(config.UList("wtf.openUrlUtil", []interface{}{}))
+	openURLUtil := utils.ToStrs(config.UList("wtf.openUrlUtil", []any{}))
 	utils.Init(openFileUtil, openURLUtil)
 
 	/* Initialize the App Manager */

--- a/modules/asana/widget.go
+++ b/modules/asana/widget.go
@@ -87,7 +87,7 @@ func (widget *Widget) Render() {
 
 func (widget *Widget) Fetch(workspaceId, projectId, mode string, sections []string, allUsers bool) ([]*TaskItem, error) {
 
-	availableModes := map[string]interface{}{
+	availableModes := map[string]any{
 		"project":          nil,
 		"project_sections": nil,
 		"workspace":        nil,

--- a/modules/clocks/settings.go
+++ b/modules/clocks/settings.go
@@ -52,7 +52,7 @@ func buildLocations(ymlConfig *config.Config) []Clock {
 
 	listLocations := ymlConfig.UList("locations")
 	for _, location := range listLocations {
-		if location, ok := location.(map[string]interface{}); ok {
+		if location, ok := location.(map[string]any); ok {
 			for k, v := range location {
 				name := k
 				zone := v.(string)

--- a/modules/covid/cases.go
+++ b/modules/covid/cases.go
@@ -10,5 +10,5 @@ type Latest struct {
 	Confirmed int `json:"confirmed"`
 	Deaths    int `json:"deaths"`
 	// Not currently used but holds information about the country
-	Locations []interface{} `json:"locations,omitempty"`
+	Locations []any `json:"locations,omitempty"`
 }

--- a/modules/covid/client.go
+++ b/modules/covid/client.go
@@ -31,7 +31,7 @@ func LatestCases() (*Cases, error) {
 }
 
 // LatestCountryCases queries the /locations endpoint, takes a query parameter: the country code
-func (widget *Widget) LatestCountryCases(countries []interface{}) ([]*Cases, error) {
+func (widget *Widget) LatestCountryCases(countries []any) ([]*Cases, error) {
 	countriesCovidData := []*Cases{}
 	for _, name := range countries {
 		countryURL := covidTrackerAPIURL + "locations?source=jhu&country_code=" + name.(string)

--- a/modules/covid/settings.go
+++ b/modules/covid/settings.go
@@ -14,7 +14,7 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	countries []interface{} `help:"Countries (codes) from which to retrieve stats."`
+	countries []any `help:"Countries (codes) from which to retrieve stats."`
 }
 
 // NewSettingsFromYAML returns the settings from the config yaml file

--- a/modules/cryptoexchanges/bittrex/settings.go
+++ b/modules/cryptoexchanges/bittrex/settings.go
@@ -24,7 +24,7 @@ type colors struct {
 
 type currency struct {
 	displayName string
-	market      []interface{}
+	market      []any
 }
 
 type summary struct {
@@ -53,11 +53,11 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 
 	settings.summary.currencies = make(map[string]*currency)
 	for key, val := range ymlConfig.UMap("summary") {
-		coercedVal := val.(map[string]interface{})
+		coercedVal := val.(map[string]any)
 
 		currency := &currency{
 			displayName: coercedVal["displayName"].(string),
-			market:      coercedVal["market"].([]interface{}),
+			market:      coercedVal["market"].([]any),
 		}
 
 		settings.summary.currencies[key] = currency

--- a/modules/cryptoexchanges/bittrex/widget.go
+++ b/modules/cryptoexchanges/bittrex/widget.go
@@ -52,7 +52,7 @@ func (widget *Widget) setSummaryList() {
 	}
 }
 
-func (widget *Widget) makeSummaryMarketList(market []interface{}) []*mCurrency {
+func (widget *Widget) makeSummaryMarketList(market []any) []*mCurrency {
 	mCurrencyList := []*mCurrency{}
 
 	for _, marketSymbol := range market {

--- a/modules/cryptoexchanges/cryptolive/price/settings.go
+++ b/modules/cryptoexchanges/cryptolive/price/settings.go
@@ -34,7 +34,7 @@ type colors struct {
 
 type currency struct {
 	displayName string
-	to          []interface{}
+	to          []any
 }
 
 type Settings struct {
@@ -66,11 +66,11 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.currencies = make(map[string]*currency)
 
 	for key, val := range ymlConfig.UMap("currencies") {
-		coercedVal := val.(map[string]interface{})
+		coercedVal := val.(map[string]any)
 
 		currency := &currency{
 			displayName: coercedVal["displayName"].(string),
-			to:          coercedVal["to"].([]interface{}),
+			to:          coercedVal["to"].([]any),
 		}
 
 		settings.currencies[key] = currency

--- a/modules/cryptoexchanges/cryptolive/settings.go
+++ b/modules/cryptoexchanges/cryptolive/settings.go
@@ -39,8 +39,8 @@ type Settings struct {
 
 	colors
 
-	currencies map[string]interface{}
-	top        map[string]interface{}
+	currencies map[string]any
+	top        map[string]any
 
 	priceSettings   *price.Settings
 	toplistSettings *toplist.Settings

--- a/modules/cryptoexchanges/cryptolive/toplist/settings.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/settings.go
@@ -35,7 +35,7 @@ type colors struct {
 type currency struct {
 	displayName string
 	limit       int
-	to          []interface{}
+	to          []any
 }
 
 type Settings struct {
@@ -67,14 +67,14 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.top = make(map[string]*currency)
 
 	for key, val := range ymlConfig.UMap("top") {
-		coercedVal := val.(map[string]interface{})
+		coercedVal := val.(map[string]any)
 
 		limit, _ := coercedVal["limit"].(int)
 
 		currency := &currency{
 			displayName: coercedVal["displayName"].(string),
 			limit:       limit,
-			to:          coercedVal["to"].([]interface{}),
+			to:          coercedVal["to"].([]any),
 		}
 
 		settings.top[key] = currency

--- a/modules/datadog/settings.go
+++ b/modules/datadog/settings.go
@@ -15,9 +15,9 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	apiKey         string        `help:"Your Datadog API key."`
-	applicationKey string        `help:"Your Datadog Application key."`
-	tags           []interface{} `help:"Array of tags you want to query monitors by."`
+	apiKey         string `help:"Your Datadog API key."`
+	applicationKey string `help:"Your Datadog Application key."`
+	tags           []any  `help:"Array of tags you want to query monitors by."`
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {

--- a/modules/digitalocean/display.go
+++ b/modules/digitalocean/display.go
@@ -38,7 +38,7 @@ func (widget *Widget) content() (string, string, bool) {
 			fmtStr += "%-12s"
 		}
 
-		vals := []interface{}{
+		vals := []any{
 			widget.RowColor(idx),
 		}
 

--- a/modules/digitalocean/settings.go
+++ b/modules/digitalocean/settings.go
@@ -16,7 +16,7 @@ const (
 
 // defaultColumns defines the default set of columns to display in the widget
 // This can be over-ridden in the cofig by explicitly defining a set of columns
-var defaultColumns = []interface{}{
+var defaultColumns = []any{
 	"Name",
 	"Status",
 	"Region.Slug",

--- a/modules/docker/utils.go
+++ b/modules/docker/utils.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 )
 
-func padSlice(padLeft bool, slice interface{}, getter func(i int) string, setter func(i int, newVal string)) {
+func padSlice(padLeft bool, slice any, getter func(i int) string, setter func(i int, newVal string)) {
 	rv := reflect.ValueOf(slice)
 	length := rv.Len()
 	maxLen := 0

--- a/modules/feedreader/settings.go
+++ b/modules/feedreader/settings.go
@@ -40,7 +40,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		credentials := make(map[string]auth)
 		feeds := make([]string, 0)
 		for url, creds := range ymlConfig.UMap("feeds") {
-			parsed, ok := creds.(map[string]interface{})
+			parsed, ok := creds.(map[string]any)
 			if !ok {
 				continue
 			}

--- a/modules/gcal/display.go
+++ b/modules/gcal/display.go
@@ -166,7 +166,7 @@ func (widget *Widget) titleColor(calEvent *CalEvent) string {
 	color := widget.settings.colors.title
 
 	for _, untypedArr := range widget.settings.colors.highlights {
-		highlightElements := utils.ToStrs(untypedArr.([]interface{}))
+		highlightElements := utils.ToStrs(untypedArr.([]any))
 
 		match, _ := regexp.MatchString(
 			strings.ToLower(highlightElements[0]),

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -17,7 +17,7 @@ type colors struct {
 	past        string `help:"The color for calendar events that have passed." values:"Any X11 color name." optional:"true"`
 	title       string `help:"The default colour for calendar event titles." values:"Any X11 color name." optional:"true"`
 
-	highlights []interface{} `help:"A list of arrays that define a regular expression pattern and a color. If a calendar event title matches a regular expression, the title will be drawn in that colour. Over-rides the default title colour." values:"An array of a valid regular expression, any X11 color name." optional:"true"`
+	highlights []any `help:"A list of arrays that define a regular expression pattern and a color. If a calendar event title matches a regular expression, the title will be drawn in that colour. Over-rides the default title colour." values:"An array of a valid regular expression, any X11 color name." optional:"true"`
 }
 
 // Settings defines the configuration options for this module

--- a/modules/gerrit/settings.go
+++ b/modules/gerrit/settings.go
@@ -23,11 +23,11 @@ type Settings struct {
 	colors
 	*cfg.Common
 
-	domain                  string        `help:"Your Gerrit corporate domain."`
-	password                string        `help:"Your Gerrit HTTP Password."`
-	projects                []interface{} `help:"A list of Gerrit project names to fetch data for."`
-	username                string        `help:"Your Gerrit username."`
-	verifyServerCertificate bool          `help:"Determines whether or not the server’s certificate chain and host name are verified." values:"true or false" optional:"true"`
+	domain                  string `help:"Your Gerrit corporate domain."`
+	password                string `help:"Your Gerrit HTTP Password."`
+	projects                []any  `help:"A list of Gerrit project names to fetch data for."`
+	username                string `help:"Your Gerrit username."`
+	verifyServerCertificate bool   `help:"Determines whether or not the server’s certificate chain and host name are verified." values:"true or false" optional:"true"`
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {

--- a/modules/gerrit/widget.go
+++ b/modules/gerrit/widget.go
@@ -147,7 +147,7 @@ func (widget *Widget) unselect() {
 	widget.display()
 }
 
-func (widget *Widget) buildProjectCollection(projectData []interface{}) []*GerritProject {
+func (widget *Widget) buildProjectCollection(projectData []any) []*GerritProject {
 	gerritProjects := []*GerritProject{}
 
 	for _, name := range projectData {

--- a/modules/git/settings.go
+++ b/modules/git/settings.go
@@ -14,15 +14,15 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	commitCount      int           `help:"The number of past commits to display." values:"A positive integer, 0..n." optional:"true"`
-	sections         []interface{} `help:"Sections to show" optional:"true"`
-	showModuleName   bool          `help:"Whether to show 'Git - ' before information in title" optional:"true" default:"true"`
-	branchInTitle    bool          `help:"Whether to show branch name in title instead of the widget body itself" optional:"true" default:"false"`
-	showFilesIfEmpty bool          `help:"Whether to show Changed Files section if no changed files" optional:"true" default:"true"`
-	lastFolderTitle  bool          `help:"Whether to show only last part of directory path instead of full path" optional:"true" default:"false"`
-	commitFormat     string        `help:"The string format for the commit message." optional:"true"`
-	dateFormat       string        `help:"The string format for the date/time in the commit message." optional:"true"`
-	repositories     []interface{} `help:"Defines which git repositories to watch." values:"A list of zero or more local file paths pointing to valid git repositories."`
+	commitCount      int    `help:"The number of past commits to display." values:"A positive integer, 0..n." optional:"true"`
+	sections         []any  `help:"Sections to show" optional:"true"`
+	showModuleName   bool   `help:"Whether to show 'Git - ' before information in title" optional:"true" default:"true"`
+	branchInTitle    bool   `help:"Whether to show branch name in title instead of the widget body itself" optional:"true" default:"false"`
+	showFilesIfEmpty bool   `help:"Whether to show Changed Files section if no changed files" optional:"true" default:"true"`
+	lastFolderTitle  bool   `help:"Whether to show only last part of directory path instead of full path" optional:"true" default:"false"`
+	commitFormat     string `help:"The string format for the commit message." optional:"true"`
+	dateFormat       string `help:"The string format for the date/time in the commit message." optional:"true"`
+	repositories     []any  `help:"Defines which git repositories to watch." values:"A list of zero or more local file paths pointing to valid git repositories."`
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -64,7 +64,7 @@ func parseCustomQueries(ymlConfig *config.Config) []customQuery {
 	if customQueries, err := ymlConfig.Map("customQueries"); err == nil {
 		for _, query := range customQueries {
 			c := customQuery{}
-			for key, value := range query.(map[string]interface{}) {
+			for key, value := range query.(map[string]any) {
 				switch key {
 				case "title":
 					c.title = value.(string)

--- a/modules/gitlab/gitlab_project.go
+++ b/modules/gitlab/gitlab_project.go
@@ -166,7 +166,7 @@ func (project *GitlabProject) loadAssignedIssues() ([]*glb.Issue, error) {
 	return issues, nil
 }
 
-func (project *GitlabProject) loadAuthoredIssues() ([]*glb.Issue, interface{}) {
+func (project *GitlabProject) loadAuthoredIssues() ([]*glb.Issue, any) {
 	state := "opened"
 	opts := glb.ListProjectIssuesOptions{
 		State:    &state,

--- a/modules/googleanalytics/client.go
+++ b/modules/googleanalytics/client.go
@@ -83,7 +83,7 @@ func makeReportServiceV4(secretPath string) (*gaV4.Service, error) {
 }
 
 func getReports(
-	serviceV4 *gaV4.Service, viewIds map[string]interface{}, displayedMonths int, serviceV3 *gaV3.Service,
+	serviceV4 *gaV4.Service, viewIds map[string]any, displayedMonths int, serviceV3 *gaV3.Service,
 ) []websiteReport {
 	startDate := fmt.Sprintf("%s-01", time.Now().AddDate(0, -displayedMonths+1, 0).Format("2006-01"))
 	var websiteReports []websiteReport

--- a/modules/googleanalytics/settings.go
+++ b/modules/googleanalytics/settings.go
@@ -15,7 +15,7 @@ type Settings struct {
 
 	months         int
 	secretFile     string `help:"Your Google client secret JSON file." values:"A string representing a file path to the JSON secret file."`
-	viewIds        map[string]interface{}
+	viewIds        map[string]any
 	enableRealtime bool
 }
 

--- a/modules/gspreadsheets/settings.go
+++ b/modules/gspreadsheets/settings.go
@@ -18,8 +18,8 @@ type Settings struct {
 	colors
 	*cfg.Common
 
-	cellAddresses []interface{}
-	cellNames     []interface{}
+	cellAddresses []any
+	cellNames     []any
 	secretFile    string
 	sheetID       string
 }

--- a/modules/ipaddresses/ipapi/settings.go
+++ b/modules/ipaddresses/ipapi/settings.go
@@ -18,7 +18,7 @@ type colors struct {
 type Settings struct {
 	colors
 	*cfg.Common
-	args []interface{} `help:"Defines what data to display and the order." values:"'ip', 'isp', 'as', 'asName', 'district', 'city', 'region', 'regionName', 'country', 'countryCode', 'continent', 'continentCode', 'coordinates', 'postalCode', 'currency', 'organization', 'timezone' and/or 'reverseDNS'"`
+	args []any `help:"Defines what data to display and the order." values:"'ip', 'isp', 'as', 'asName', 'district', 'city', 'region', 'regionName', 'country', 'countryCode', 'continent', 'continentCode', 'coordinates', 'postalCode', 'currency', 'organization', 'timezone' and/or 'reverseDNS'"`
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {

--- a/modules/krisinformation/client.go
+++ b/modules/krisinformation/client.go
@@ -25,20 +25,20 @@ type Krisinformation []struct {
 	Preamble    string    `json:"Preamble"`
 	BodyText    string    `json:"BodyText"`
 	Area        []struct {
-		Type                string      `json:"Type"`
-		Description         string      `json:"Description"`
-		Coordinate          string      `json:"Coordinate"`
-		GeometryInformation interface{} `json:"GeometryInformation"`
+		Type                string `json:"Type"`
+		Description         string `json:"Description"`
+		Coordinate          string `json:"Coordinate"`
+		GeometryInformation any    `json:"GeometryInformation"`
 	} `json:"Area"`
-	Web        string        `json:"Web"`
-	Language   string        `json:"Language"`
-	Event      string        `json:"Event"`
-	SenderName string        `json:"SenderName"`
-	Push       bool          `json:"Push"`
-	BodyLinks  []interface{} `json:"BodyLinks"`
-	SourceID   int           `json:"SourceID"`
-	IsVma      bool          `json:"IsVma"`
-	IsTestVma  bool          `json:"IsTestVma"`
+	Web        string `json:"Web"`
+	Language   string `json:"Language"`
+	Event      string `json:"Event"`
+	SenderName string `json:"SenderName"`
+	Push       bool   `json:"Push"`
+	BodyLinks  []any  `json:"BodyLinks"`
+	SourceID   int    `json:"SourceID"`
+	IsVma      bool   `json:"IsVma"`
+	IsTestVma  bool   `json:"IsTestVma"`
 }
 
 // Client holds or configuration

--- a/modules/mercurial/settings.go
+++ b/modules/mercurial/settings.go
@@ -13,9 +13,9 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	commitCount  int           `help:"The number of past commits to display." optional:"true"`
-	commitFormat string        `help:"The string format for the commit message." optional:"true"`
-	repositories []interface{} `help:"Defines which mercurial repositories to watch." values:"A list of zero or more local file paths pointing to valid mercurial repositories."`
+	commitCount  int    `help:"The number of past commits to display." optional:"true"`
+	commitFormat string `help:"The string format for the commit message." optional:"true"`
+	repositories []any  `help:"Defines which mercurial repositories to watch." values:"A list of zero or more local file paths pointing to valid mercurial repositories."`
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -67,7 +67,7 @@ func (widget *Widget) nbascore() (string, string, bool) {
 	if err != nil {
 		return title, err.Error(), true
 	}
-	result := map[string]interface{}{}
+	result := map[string]any{}
 	err = json.Unmarshal(contents, &result)
 	if err != nil {
 		return title, err.Error(), true
@@ -75,14 +75,14 @@ func (widget *Widget) nbascore() (string, string, bool) {
 
 	allGame := fmt.Sprintf(" [%s]", widget.settings.Colors.Subheading) + (cur.Format(utils.FriendlyDateFormat) + "\n\n") + "[white]"
 
-	for _, game := range result["games"].([]interface{}) {
+	for _, game := range result["games"].([]any) {
 		vTeam, hTeam, vScore, hScore := "", "", "", ""
 		quarter := 0.
 		activate := false
-		for keyGame, team := range game.(map[string]interface{}) { // assertion
+		for keyGame, team := range game.(map[string]any) { // assertion
 			switch keyGame {
 			case "vTeam", "hTeam":
-				for keyTeam, stat := range team.(map[string]interface{}) {
+				for keyTeam, stat := range team.(map[string]any) {
 					if keyTeam == "triCode" {
 						if keyGame == "vTeam" {
 							vTeam = stat.(string)
@@ -98,7 +98,7 @@ func (widget *Widget) nbascore() (string, string, bool) {
 					}
 				}
 			case "period":
-				for keyTeam, stat := range team.(map[string]interface{}) {
+				for keyTeam, stat := range team.(map[string]any) {
 					if keyTeam == "current" {
 						quarter = stat.(float64)
 					}

--- a/modules/newrelic/client/alert_conditions.go
+++ b/modules/newrelic/client/alert_conditions.go
@@ -38,7 +38,7 @@ func (o *AlertConditionOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"policy_id": o.policyID,
 		"page":      o.Page,
 	})

--- a/modules/newrelic/client/alert_events.go
+++ b/modules/newrelic/client/alert_events.go
@@ -36,7 +36,7 @@ func (o *AlertEventOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"filter[product]":         o.Filter.Product,
 		"filter[entity_type]":     o.Filter.EntityType,
 		"filter[entity_group_id]": o.Filter.EntityGroupID,

--- a/modules/newrelic/client/application_deployments.go
+++ b/modules/newrelic/client/application_deployments.go
@@ -47,7 +47,7 @@ func (o *ApplicationDeploymentOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"page": o.Page,
 	})
 }

--- a/modules/newrelic/client/application_hosts.go
+++ b/modules/newrelic/client/application_hosts.go
@@ -86,7 +86,7 @@ func (o *ApplicationHostsOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"filter[hostname]": o.Filter.Hostname,
 		"filter[ids]":      o.Filter.IDs,
 		"page":             o.Page,

--- a/modules/newrelic/client/application_instances.go
+++ b/modules/newrelic/client/application_instances.go
@@ -86,7 +86,7 @@ func (o *ApplicationInstancesOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"filter[hostname]": o.Filter.Hostname,
 		"filter[ids]":      o.Filter.IDs,
 		"page":             o.Page,

--- a/modules/newrelic/client/applications.go
+++ b/modules/newrelic/client/applications.go
@@ -75,7 +75,7 @@ func (o *ApplicationOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"filter[name]":     o.Filter.Name,
 		"filter[host]":     o.Filter.Host,
 		"filter[ids]":      o.Filter.IDs,

--- a/modules/newrelic/client/browser_applications.go
+++ b/modules/newrelic/client/browser_applications.go
@@ -40,7 +40,7 @@ func (o *BrowserApplicationsOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"filter[name]": o.Filter.Name,
 		"filter[ids]":  o.Filter.IDs,
 		"page":         o.Page,

--- a/modules/newrelic/client/http_helper.go
+++ b/modules/newrelic/client/http_helper.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func (c *Client) doGet(path string, params fmt.Stringer, out interface{}) error {
+func (c *Client) doGet(path string, params fmt.Stringer, out any) error {
 	var s string
 	if params != nil {
 		s = params.String()
@@ -26,7 +26,7 @@ func (c *Client) doGet(path string, params fmt.Stringer, out interface{}) error 
 	return c.doRequest(req, out)
 }
 
-func (c *Client) doRequest(req *http.Request, out interface{}) error {
+func (c *Client) doRequest(req *http.Request, out any) error {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func (c *Client) doRequest(req *http.Request, out interface{}) error {
 	return nil
 }
 
-func encodeGetParams(params map[string]interface{}) string {
+func encodeGetParams(params map[string]any) string {
 	s := url.Values{}
 	for k, v := range params {
 		switch val := v.(type) {

--- a/modules/newrelic/client/key_transactions.go
+++ b/modules/newrelic/client/key_transactions.go
@@ -68,7 +68,7 @@ func (o *KeyTransactionsOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"filter[name]": o.Filter.Name,
 		"filter[ids]":  o.Filter.IDs,
 		"page":         o.Page,

--- a/modules/newrelic/client/legacy_alert_policies.go
+++ b/modules/newrelic/client/legacy_alert_policies.go
@@ -46,7 +46,7 @@ func (o *LegacyAlertPolicyOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"filter[name]": o.Filter.Name,
 		"page":         o.Page,
 	})

--- a/modules/newrelic/client/metrics.go
+++ b/modules/newrelic/client/metrics.go
@@ -56,7 +56,7 @@ func (o *MetricsOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"name": o.Name,
 		"page": o.Page,
 	})
@@ -66,7 +66,7 @@ func (o *MetricDataOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"names[]":   o.Names,
 		"values[]":  o.Values,
 		"from":      o.From,

--- a/modules/newrelic/client/notification_channels.go
+++ b/modules/newrelic/client/notification_channels.go
@@ -45,7 +45,7 @@ func (o *NotificationChannelsOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"filter[type]": o.Filter.Type,
 		"filter[ids]":  o.Filter.IDs,
 		"page":         o.Page,

--- a/modules/newrelic/client/servers.go
+++ b/modules/newrelic/client/servers.go
@@ -81,7 +81,7 @@ func (o *ServersOptions) String() string {
 	if o == nil {
 		return ""
 	}
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"filter[name]":     o.Filter.Name,
 		"filter[host]":     o.Filter.Host,
 		"filter[ids]":      o.Filter.IDs,

--- a/modules/newrelic/client/usages.go
+++ b/modules/newrelic/client/usages.go
@@ -28,7 +28,7 @@ type usageParams struct {
 }
 
 func (o *usageParams) String() string {
-	return encodeGetParams(map[string]interface{}{
+	return encodeGetParams(map[string]any{
 		"start_date":          o.Start.Format("2006-01-02"),
 		"end_date":            o.End.Format("2006-01-02"),
 		"include_subaccounts": o.IncludeSubaccount,

--- a/modules/newrelic/settings.go
+++ b/modules/newrelic/settings.go
@@ -15,9 +15,9 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	apiKey         string        `help:"Your New Relic API token."`
-	deployCount    int           `help:"The number of past deploys to display on screen." optional:"true"`
-	applicationIDs []interface{} `help:"The integer ID of the New Relic application you wish to report on."`
+	apiKey         string `help:"Your New Relic API token."`
+	deployCount    int    `help:"The number of past deploys to display on screen." optional:"true"`
+	applicationIDs []any  `help:"The integer ID of the New Relic application you wish to report on."`
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {

--- a/modules/pagerduty/settings.go
+++ b/modules/pagerduty/settings.go
@@ -16,15 +16,15 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	apiKey           string        `help:"Your PagerDuty API key."`
-	escalationFilter []interface{} `help:"An array of schedule names you want to filter the OnCalls on."`
-	myName           string        `help:"The name to highlight when on-call in PagerDuty."`
-	scheduleIDs      []interface{} `help:"An array of schedule IDs you want to restrict the OnCalls query to."`
-	showIncidents    bool          `help:"Whether or not to list incidents." optional:"true"`
-	showOnCallEnd    bool          `help:"Whether or not to display the date the oncall schedule ends." optional:"true"`
-	showSchedules    bool          `help:"Whether or not to show schedules." optional:"true"`
-	teamIDs          []interface{} `help:"An array of team IDs to restrict the incidents query to" optional:"true"`
-	userIDs          []interface{} `help:"An array of user IDs to restrict the incidents query to" optional:"true"`
+	apiKey           string `help:"Your PagerDuty API key."`
+	escalationFilter []any  `help:"An array of schedule names you want to filter the OnCalls on."`
+	myName           string `help:"The name to highlight when on-call in PagerDuty."`
+	scheduleIDs      []any  `help:"An array of schedule IDs you want to restrict the OnCalls query to."`
+	showIncidents    bool   `help:"Whether or not to list incidents." optional:"true"`
+	showOnCallEnd    bool   `help:"Whether or not to display the date the oncall schedule ends." optional:"true"`
+	showSchedules    bool   `help:"Whether or not to show schedules." optional:"true"`
+	teamIDs          []any  `help:"An array of team IDs to restrict the incidents query to" optional:"true"`
+	userIDs          []any  `help:"An array of user IDs to restrict the incidents query to" optional:"true"`
 }
 
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
@@ -35,12 +35,12 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		apiKey:           ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_PAGERDUTY_API_KEY"))),
 		escalationFilter: ymlConfig.UList("escalationFilter"),
 		myName:           ymlConfig.UString("myName"),
-		scheduleIDs:      ymlConfig.UList("scheduleIDs", []interface{}{}),
+		scheduleIDs:      ymlConfig.UList("scheduleIDs", []any{}),
 		showIncidents:    ymlConfig.UBool("showIncidents", true),
 		showOnCallEnd:    ymlConfig.UBool("showOnCallEnd", false),
 		showSchedules:    ymlConfig.UBool("showSchedules", true),
-		teamIDs:          ymlConfig.UList("teamIDs", []interface{}{}),
-		userIDs:          ymlConfig.UList("userIDs", []interface{}{}),
+		teamIDs:          ymlConfig.UList("teamIDs", []any{}),
+		userIDs:          ymlConfig.UList("userIDs", []any{}),
 	}
 
 	cfg.ModuleSecret(name, globalConfig, &settings.apiKey).Load()

--- a/modules/pocket/client.go
+++ b/modules/pocket/client.go
@@ -62,13 +62,13 @@ type ItemLists struct {
 }
 
 type request struct {
-	requestBody interface{}
+	requestBody any
 	method      string
 	headers     map[string]string
 	url         string
 }
 
-func (*Client) request(req request, result interface{}) error {
+func (*Client) request(req request, result any) error {
 	var reqBody io.Reader
 	if req.requestBody != nil {
 		jsonValues, err := json.Marshal(req.requestBody)

--- a/modules/steam/settings.go
+++ b/modules/steam/settings.go
@@ -27,7 +27,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 
 		numberOfResults: ymlConfig.UInt("numberOfResults", 10),
 		key:             ymlConfig.UString("key", os.Getenv("STEAM_API_KEY")),
-		userIds:         utils.ToStrs(ymlConfig.UList("userIds", make([]interface{}, 0))),
+		userIds:         utils.ToStrs(ymlConfig.UList("userIds", make([]any, 0))),
 	}
 	return &settings
 }

--- a/modules/stocks/yfinance/widget.go
+++ b/modules/stocks/yfinance/widget.go
@@ -55,7 +55,7 @@ func (widget *Widget) content() string {
 	t := table.NewWriter()
 	t.SetStyle(tableStyle())
 	for _, yq := range yquotes {
-		t.AppendRow([]interface{}{
+		t.AppendRow([]any{
 			GetMarketIcon(yq.MarketState),
 			yq.Symbol,
 			fmt.Sprintf("%8.2f %s", yq.MarketPrice, yq.Currency),

--- a/modules/textfile/settings.go
+++ b/modules/textfile/settings.go
@@ -14,7 +14,7 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	filePaths   []interface{}
+	filePaths   []any
 	format      bool
 	formatStyle string
 	wrapText    bool

--- a/modules/todo/settings.go
+++ b/modules/todo/settings.go
@@ -28,7 +28,7 @@ type Settings struct {
 	parseTags         bool
 	tagColor          string
 	tagsAtEnd         bool
-	hideTags          []interface{}
+	hideTags          []any
 	hiddenNumInTitle  bool
 }
 

--- a/modules/todo_plus/backend/todoist.go
+++ b/modules/todo_plus/backend/todoist.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Todoist struct {
-	projects []interface{}
+	projects []any
 }
 
 func (todo *Todoist) Title() string {

--- a/modules/todo_plus/backend/trello.go
+++ b/modules/todo_plus/backend/trello.go
@@ -13,7 +13,7 @@ type Trello struct {
 	boardName string
 	client    *trello.Client
 	board     string
-	projects  []interface{}
+	projects  []any
 }
 
 func (todo *Trello) Title() string {

--- a/modules/todo_plus/settings.go
+++ b/modules/todo_plus/settings.go
@@ -57,7 +57,7 @@ func FromTrello(name string, ymlConfig *config.Config, globalConfig *config.Conf
 	cfg.ModuleSecret(name, globalConfig, &apiKey).Load()
 	board := ymlConfig.UString("board")
 	username := ymlConfig.UString("username")
-	var lists []interface{}
+	var lists []any
 	list, err := ymlConfig.String("list")
 	if err == nil {
 		lists = append(lists, list)

--- a/modules/twitch/settings.go
+++ b/modules/twitch/settings.go
@@ -27,8 +27,8 @@ type Settings struct {
 	userLogins      []string `help:"Twitch user names" optional:"true"`
 }
 
-func defaultLanguage() []interface{} {
-	var defaults []interface{}
+func defaultLanguage() []any {
+	var defaults []any
 	defaults = append(defaults, "en")
 	return defaults
 }
@@ -45,9 +45,9 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		userAccessToken: ymlConfig.UString("userAccessToken", os.Getenv("TWITCH_USER_ACCESS_TOKEN")),
 		languages:       utils.ToStrs(ymlConfig.UList("languages", defaultLanguage())),
 		streamType:      ymlConfig.UString("streamType", "live"),
-		gameIds:         utils.ToStrs(ymlConfig.UList("gameIds", make([]interface{}, 0))),
-		userIds:         utils.ToStrs(ymlConfig.UList("userIds", make([]interface{}, 0))),
-		userLogins:      utils.ToStrs(ymlConfig.UList("userLogins", make([]interface{}, 0))),
+		gameIds:         utils.ToStrs(ymlConfig.UList("gameIds", make([]any, 0))),
+		userIds:         utils.ToStrs(ymlConfig.UList("userIds", make([]any, 0))),
+		userLogins:      utils.ToStrs(ymlConfig.UList("userLogins", make([]any, 0))),
 	}
 	return &settings
 }

--- a/modules/twitter/settings.go
+++ b/modules/twitter/settings.go
@@ -19,7 +19,7 @@ type Settings struct {
 	consumerKey    string
 	consumerSecret string
 	count          int
-	screenNames    []interface{}
+	screenNames    []any
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {

--- a/modules/twitterstats/settings.go
+++ b/modules/twitterstats/settings.go
@@ -18,7 +18,7 @@ type Settings struct {
 	bearerToken    string
 	consumerKey    string
 	consumerSecret string
-	screenNames    []interface{}
+	screenNames    []any
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {

--- a/modules/weatherservices/weather/settings.go
+++ b/modules/weatherservices/weather/settings.go
@@ -21,7 +21,7 @@ type Settings struct {
 	*cfg.Common
 
 	apiKey   string
-	cityIDs  []interface{}
+	cityIDs  []any
 	language string
 	tempUnit string
 	useEmoji bool

--- a/modules/zendesk/client.go
+++ b/modules/zendesk/client.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Resource struct {
-	Response interface{}
+	Response any
 	Raw      string
 }
 

--- a/modules/zendesk/tickets.go
+++ b/modules/zendesk/tickets.go
@@ -14,35 +14,35 @@ type TicketArray struct {
 }
 
 type Ticket struct {
-	Id                    uint64      `json:"id"`
-	URL                   string      `json:"url"`
-	ExternalId            string      `json:"external_id"`
-	CreatedAt             string      `json:"created_at"`
-	UpdatedAt             string      `json:"updated_at"`
-	Type                  string      `json:"type"`
-	Subject               string      `json:"subject"`
-	RawSubject            string      `json:"raw_subject"`
-	Description           string      `json:"description"`
-	Priority              string      `json:"priority"`
-	Status                string      `json:"status"`
-	Recipient             string      `json:"recipient"`
-	RequesterId           uint64      `json:"requester_id"`
-	SubmitterId           uint64      `json:"submitter_id"`
-	AssigneeId            uint64      `json:"assignee_id"`
-	OrganizationId        uint32      `json:"organization_id"`
-	GroupId               uint32      `json:"group_id"`
-	CollaboratorIds       []int64     `json:"collaborator_ids"`
-	ForumTopicId          uint32      `json:"forum_topic_id"`
-	ProblemId             uint32      `json:"problem_id"`
-	HasIncidents          bool        `json:"has_incidents"`
-	DueAt                 string      `json:"due_at"`
-	Tags                  []string    `json:"tags"`
-	Satisfaction_rating   string      `json:"satisfaction_rating"`
-	Ticket_form_id        uint32      `json:"ticket_form_id"`
-	Sharing_agreement_ids interface{} `json:"sharing_agreement_ids"`
-	Via                   interface{} `json:"via"`
-	Custom_Fields         interface{} `json:"custom_fields"`
-	Fields                interface{} `json:"fields"`
+	Id                    uint64   `json:"id"`
+	URL                   string   `json:"url"`
+	ExternalId            string   `json:"external_id"`
+	CreatedAt             string   `json:"created_at"`
+	UpdatedAt             string   `json:"updated_at"`
+	Type                  string   `json:"type"`
+	Subject               string   `json:"subject"`
+	RawSubject            string   `json:"raw_subject"`
+	Description           string   `json:"description"`
+	Priority              string   `json:"priority"`
+	Status                string   `json:"status"`
+	Recipient             string   `json:"recipient"`
+	RequesterId           uint64   `json:"requester_id"`
+	SubmitterId           uint64   `json:"submitter_id"`
+	AssigneeId            uint64   `json:"assignee_id"`
+	OrganizationId        uint32   `json:"organization_id"`
+	GroupId               uint32   `json:"group_id"`
+	CollaboratorIds       []int64  `json:"collaborator_ids"`
+	ForumTopicId          uint32   `json:"forum_topic_id"`
+	ProblemId             uint32   `json:"problem_id"`
+	HasIncidents          bool     `json:"has_incidents"`
+	DueAt                 string   `json:"due_at"`
+	Tags                  []string `json:"tags"`
+	Satisfaction_rating   string   `json:"satisfaction_rating"`
+	Ticket_form_id        uint32   `json:"ticket_form_id"`
+	Sharing_agreement_ids any      `json:"sharing_agreement_ids"`
+	Via                   any      `json:"via"`
+	Custom_Fields         any      `json:"custom_fields"`
+	Fields                any      `json:"fields"`
 }
 
 func (widget *Widget) listTickets(pag ...string) (*TicketArray, error) {

--- a/modules/zendesk/widget.go
+++ b/modules/zendesk/widget.go
@@ -80,13 +80,13 @@ func (widget *Widget) format(ticket Ticket, idx int) string {
 
 // this is a nasty means of extracting the actual name of the requester from the Via interface of the Ticket.
 // very very open to improvements on this
-func (widget *Widget) parseRequester(ticket Ticket) interface{} {
+func (widget *Widget) parseRequester(ticket Ticket) any {
 	viaMap := ticket.Via
-	via := viaMap.(map[string]interface{})
+	via := viaMap.(map[string]any)
 	source := via["source"]
-	fromMap, _ := source.(map[string]interface{})
+	fromMap, _ := source.(map[string]any)
 	from := fromMap["from"]
-	fromValMap := from.(map[string]interface{})
+	fromValMap := from.(map[string]any)
 	fromName := fromValMap["name"]
 	return fromName
 }

--- a/support/github.go
+++ b/support/github.go
@@ -199,7 +199,7 @@ func (ghUser *GitHubUser) loadContributorStatus(ctx context.Context) (bool, erro
 
 // loadSponsorStatus figures out if this GitHub account has sponsored WTF
 func (ghUser *GitHubUser) loadSponsorStatus(ctx context.Context) (bool, error) {
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		"loginName": githubv4.String(ghUser.loginName),
 	}
 

--- a/utils/conversions.go
+++ b/utils/conversions.go
@@ -7,7 +7,7 @@ import (
 /* -------------------- Map Conversion -------------------- */
 
 // MapToStrs takes a map of interfaces and returns a map of strings
-func MapToStrs(aMap map[string]interface{}) map[string]string {
+func MapToStrs(aMap map[string]any) map[string]string {
 	results := make(map[string]string, len(aMap))
 
 	for key, val := range aMap {
@@ -31,7 +31,7 @@ func IntsToUints(slice []int) []uint {
 }
 
 // ToInts takes a slice of interfaces and returns a slice of ints
-func ToInts(slice []interface{}) []int {
+func ToInts(slice []any) []int {
 	results := make([]int, len(slice))
 
 	for i, val := range slice {
@@ -42,7 +42,7 @@ func ToInts(slice []interface{}) []int {
 }
 
 // ToStrs takes a slice of interfaces and returns a slice of strings
-func ToStrs(slice []interface{}) []string {
+func ToStrs(slice []any) []string {
 	results := make([]string, len(slice))
 
 	for i, val := range slice {
@@ -58,7 +58,7 @@ func ToStrs(slice []interface{}) []string {
 }
 
 // ToUints takes a slice of interfaces and returns a slice of ints
-func ToUints(slice []interface{}) []uint {
+func ToUints(slice []any) []uint {
 	results := make([]uint, len(slice))
 
 	for i, val := range slice {

--- a/utils/conversions_test.go
+++ b/utils/conversions_test.go
@@ -13,7 +13,7 @@ func Test_MapToStrs(t *testing.T) {
 		"c": "c",
 	}
 
-	source := make(map[string]interface{})
+	source := make(map[string]any)
 	for _, val := range expected {
 		source[val] = val
 	}
@@ -50,7 +50,7 @@ func Test_IntsToUints(t *testing.T) {
 func Test_ToInts(t *testing.T) {
 	expected := []int{1, 2, 3}
 
-	source := make([]interface{}, len(expected))
+	source := make([]any, len(expected))
 	for idx, val := range expected {
 		source[idx] = val
 	}
@@ -62,12 +62,12 @@ func Test_ToStrs(t *testing.T) {
 	expectedInts := []int{1, 2, 3}
 	expectedStrs := []string{"1", "2", "3"}
 
-	fromInts := make([]interface{}, 3)
+	fromInts := make([]any, 3)
 	for idx, val := range expectedInts {
 		fromInts[idx] = val
 	}
 
-	fromStrs := make([]interface{}, 3)
+	fromStrs := make([]any, 3)
 	for idx, val := range expectedStrs {
 		fromStrs[idx] = val
 	}
@@ -79,7 +79,7 @@ func Test_ToStrs(t *testing.T) {
 func Test_ToUints(t *testing.T) {
 	expected := []uint{1, 2, 3}
 
-	source := make([]interface{}, len(expected))
+	source := make([]any, len(expected))
 	for idx, val := range expected {
 		source[idx] = val
 	}

--- a/utils/help_parser.go
+++ b/utils/help_parser.go
@@ -12,7 +12,7 @@ import (
 
 /* -------------------- Exported Functions -------------------- */
 
-func HelpFromInterface(item interface{}) string {
+func HelpFromInterface(item any) string {
 	result := ""
 	t := reflect.TypeOf(item)
 

--- a/utils/reflective.go
+++ b/utils/reflective.go
@@ -7,7 +7,7 @@ import (
 
 // StringValueForProperty returns a string value for the given property
 // If the property doesn't exist, it returns an error
-func StringValueForProperty(ref interface{}, propName string) (string, error) {
+func StringValueForProperty(ref any, propName string) (string, error) {
 	v := reflect.ValueOf(ref)
 	refVal := reflect.Indirect(v).FieldByName(propName)
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -134,7 +134,7 @@ func ReadFileBytes(filePath string) ([]byte, error) {
 }
 
 // ParseJSON is a standard JSON reader from text
-func ParseJSON(obj interface{}, text io.Reader) error {
+func ParseJSON(obj any, text io.Reader) error {
 	d := json.NewDecoder(text)
 	return d.Decode(obj)
 }

--- a/view/bargraph_test.go
+++ b/view/bargraph_test.go
@@ -42,7 +42,7 @@ func newTestGraph(graphStars int, graphIcon string) *BarGraph {
 		"testapp",
 		&cfg.Common{
 			Config: &config.Config{
-				Root: map[string]interface{}{
+				Root: map[string]any{
 					"graphStars": graphStars,
 					"graphIcon":  graphIcon,
 				},

--- a/view/multisource_widget.go
+++ b/view/multisource_widget.go
@@ -84,7 +84,7 @@ func (widget *MultiSourceWidget) SetDisplayFunction(displayFunc func()) {
 /* -------------------- Unexported Functions -------------------- */
 
 func (widget *MultiSourceWidget) loadSources() {
-	var empty []interface{}
+	var empty []any
 
 	single := widget.moduleConfig.Config.UString(widget.singular, "")
 	multiple := widget.moduleConfig.Config.UList(widget.plural, empty)


### PR DESCRIPTION
Rewrites `interface{}` to `any` using `gofmt`

[_Created by Sourcegraph batch change `christine/Go-upgrade-type`._](https://demo.sourcegraph.com/users/christine/batch-changes/Go-upgrade-type)